### PR TITLE
Register to HologramManager new holograms

### DIFF
--- a/src/main/java/eu/decentsoftware/holograms/api/DHAPI.java
+++ b/src/main/java/eu/decentsoftware/holograms/api/DHAPI.java
@@ -99,6 +99,7 @@ public final class DHAPI {
         }
         hologram.showAll();
         hologram.save();
+        DecentHologramsAPI.get().getHologramManager().registerHologram(hologram);
         return hologram;
     }
 


### PR DESCRIPTION
Without this line of code, the file is created, but the hologram is not registered. So any modification of the hologram's file doesn't work because it says it's already existing, and any edit from commands is not possible. A full restart of the server is needed to fix it.

I'm not sure if `DecentHologramsAPI.get().getHologramManager()` is the best way to access `HologramManager` from the `DHAPI` class. It's what I used in my plugin and with solution it works.